### PR TITLE
Sample of using src/pages/ file-system to define pageData

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -15,46 +15,6 @@ exports.onCreateWebpackConfig = async ({ stage, actions }) => {
   }
 }
 
-/** @type {import('gatsby').GatsbyNode['createPages']} */
-exports.createPages = async ({ graphql: gql, actions, reporter }) => {
-  const { createPage } = actions
-  // NOTE: This is a hack to get IDE syntax highlighting on gatsby's GQL function
-  /** @type {(parts: TemplateStringsArray) => Promise<{ data?: any; errors?: Error[] }>} */
-  const graphql = ([query]) => gql(query)
-
-  await createFaq()
-
-  async function createFaq() {
-    const noop = path.resolve(`./src/templates/noop.tsx`)
-
-    const faq = await graphql`
-      {
-        file(relativePath: { eq: "faq.yml" }) {
-          yaml: childPagesYaml {
-            id
-            title
-            description
-            subtopics {
-              subtopic
-              questions {
-                question
-                answer
-              }
-            }
-          }
-        }
-      }
-    `
-
-    if (faq.errors) {
-      reporter.panicOnBuild(`There was an error loading your FAQ`, faq.errors)
-      return
-    }
-
-    createPage({ path: "/faq", component: noop, context: faq.data.file.yaml })
-  }
-}
-
 exports.onCreateNode = ({ node, actions, getNode }) => {
   const { createNodeField } = actions
 

--- a/src/pages/faq.ts
+++ b/src/pages/faq.ts
@@ -1,0 +1,22 @@
+import { graphql } from "gatsby"
+
+export default () => null
+
+export const query = graphql`
+  query FaqQuery {
+    file(relativePath: { eq: "faq.yml" }) {
+      yaml: childPagesYaml {
+        id
+        title
+        description
+        subtopics {
+          subtopic
+          questions {
+            question
+            answer
+          }
+        }
+      }
+    }
+  }
+`


### PR DESCRIPTION
I'm split about which approach to take going forward. Calling `createPage()` manually gives you a little bit more flexibility in how you set the pageData and how it can be formatted, however I'm worried that when there are a lot of pages then `gatsby-node.js` will become very cluttered.

Creating `src/pages/faq.ts` allows Gatsby to automatically wire up the `createPage()` call automatically, but you lose some flexibility (your formatting of the output pageData is limited to only what you can put in the graphql query)

@nsmmrs do you have a preference on this?